### PR TITLE
Log Partition Variance Loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Currently, the implemented losses are:
 - Detailed Balance
 - Trajectory Balance
 - Sub-Trajectory Balance. By default, each sub-trajectory is weighted geometrically (within the trajectory) depending on its length. This corresponds to the strategy defined [here](https://www.semanticscholar.org/reader/f2c32fe3f7f3e2e9d36d833e32ec55fc93f900f5). Other strategies exist and are implemented [here](https://github.com/saleml/gfn/blob/master/src/gfn/losses/sub_trajectory_balance.py).
+- Log Partition Variance loss. Introduced [here](https://arxiv.org/abs/2302.05446)
 
 ### Solving for the flows using Dynamic Programming
 

--- a/scripts/configs/loss.py
+++ b/scripts/configs/loss.py
@@ -19,8 +19,10 @@ from gfn.losses import (
     DetailedBalance,
     FlowMatching,
     FMParametrization,
+    LogPartitionVarianceLoss,
     Loss,
     Parametrization,
+    PFBasedParametrization,
     SubTBParametrization,
     SubTrajectoryBalance,
     TBParametrization,
@@ -185,6 +187,15 @@ class TBLossConfig(PFBasedLossConfig):
 
 
 @dataclass
+class LogPartitionVarianceLossConfig(PFBasedLossConfig):
+    def parse(self, env: Env) -> Tuple[Parametrization, Loss]:
+        logit_PF, logit_PB = self.get_estimators(env)
+        parametrization = PFBasedParametrization(logit_PF, logit_PB)
+        loss = LogPartitionVarianceLoss(parametrization)
+        return (parametrization, loss)
+
+
+@dataclass
 class LossConfig(JsonSerializable):
     loss: BaseLossConfig = subgroups(
         {
@@ -192,6 +203,7 @@ class LossConfig(JsonSerializable):
             "DB": DBLossConfig,
             "TB": TBLossConfig,
             "SubTB": SubTBLossConfig,
+            "ZVar": LogPartitionVarianceLossConfig,
         },
         default=TBLossConfig(),
     )

--- a/src/gfn/losses/__init__.py
+++ b/src/gfn/losses/__init__.py
@@ -9,4 +9,8 @@ from .base import (
 from .detailed_balance import DBParametrization, DetailedBalance
 from .flow_matching import FlowMatching, FMParametrization
 from .sub_trajectory_balance import SubTBParametrization, SubTrajectoryBalance
-from .trajectory_balance import TBParametrization, TrajectoryBalance
+from .trajectory_balance import (
+    LogPartitionVarianceLoss,
+    TBParametrization,
+    TrajectoryBalance,
+)

--- a/src/gfn/losses/base.py
+++ b/src/gfn/losses/base.py
@@ -67,7 +67,7 @@ class Parametrization(ABC):
 
 @dataclass
 class PFBasedParametrization(Parametrization, ABC):
-    r"Base class for parametrizations that explicitly used $P_F$"
+    r"Base class for parametrizations that explicitly uses $P_F$"
     logit_PF: LogitPFEstimator
     logit_PB: LogitPBEstimator
 

--- a/testing/test_parametrizations_and_losses.py
+++ b/testing/test_parametrizations_and_losses.py
@@ -12,7 +12,12 @@ from gfn.estimators import (
 from gfn.losses.detailed_balance import DBParametrization, DetailedBalance
 from gfn.losses.flow_matching import FlowMatching, FMParametrization
 from gfn.losses.sub_trajectory_balance import SubTBParametrization, SubTrajectoryBalance
-from gfn.losses.trajectory_balance import TBParametrization, TrajectoryBalance
+from gfn.losses.trajectory_balance import (
+    LogPartitionVarianceLoss,
+    PFBasedParametrization,
+    TBParametrization,
+    TrajectoryBalance,
+)
 from gfn.samplers.actions_samplers import DiscreteActionsSampler
 from gfn.samplers.trajectories_sampler import TrajectoriesSampler
 
@@ -58,6 +63,7 @@ def test_FM(env_name: int, ndim: int, module_name: str):
     [
         ("DB", None),
         ("TB", None),
+        ("ZVar", None),
         ("SubTB", "DB"),
         ("SubTB", "TB"),
         ("SubTB", "ModifiedDB"),
@@ -109,6 +115,9 @@ def test_PFBasedParametrization(
     elif parametrization_name == "TB":
         parametrization = TBParametrization(logit_PF, logit_PB, logZ)
         loss_cls = TrajectoryBalance
+    elif parametrization_name == "ZVar":
+        parametrization = PFBasedParametrization(logit_PF, logit_PB)
+        loss_cls = LogPartitionVarianceLoss
     elif parametrization_name == "SubTB":
         parametrization = SubTBParametrization(logit_PF, logit_PB, logF)
         loss_cls = SubTrajectoryBalance


### PR DESCRIPTION
This PR adds an implementation of the [Log Partition Variance loss](https://arxiv.org/abs/2302.05446) to the library. 

Files modified:
- The loss was added in https://github.com/saleml/gfn/blob/master/src/gfn/losses/trajectory_balance.py. The corresponding loss class was added to https://github.com/saleml/gfn/blob/master/src/gfn/losses/__init__.py for easier imports.
- A test for the loss was added in https://github.com/saleml/gfn/blob/master/testing/test_parametrizations_and_losses.py.
- A loss config was added as a `dataclass` to https://github.com/saleml/gfn/blob/master/scripts/configs/loss.py.
- The [README](https://github.com/saleml/gfn/blob/master/README.md) was modified to indicate that this loss is implemented.
